### PR TITLE
Update clients.html

### DIFF
--- a/partials/views/clients.html
+++ b/partials/views/clients.html
@@ -36,7 +36,7 @@
                 </th>
                 <th class="col-min" ng-click="predicate = '-status'; reverse=!reverse"><i class="fa fa-sort"></i></th>
                 <th class="col-sm-2" ng-click="predicate = 'name'; reverse=!reverse">Name <i class="fa fa-sort"></i></th>
-                <th class="col-sm-1" ng-click="predicate = 'address'; reverse=!reverse">IP <i class="fa fa-sort"></i></th>
+                <th class="col-sm-2" ng-click="predicate = 'address'; reverse=!reverse">IP <i class="fa fa-sort"></i></th>
                 <th class="col-sm-5" ng-click="predicate = 'output'; reverse=!reverse">Events <i class="fa fa-sort"></i></th>
                 <th class="col-dc" ng-click="predicate = 'dc'; reverse=!reverse"><i class="fa fa-cloud" tooltip-placement="top" tooltip="Datacenter"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-dc" ng-click="predicate = 'version'; reverse=!reverse"><i class="fa fa-upload" tooltip-placement="top" tooltip="Sensu Version"></i> <i class="fa fa-sort"></i></th>


### PR DESCRIPTION
The 'ip address' column is too small, and is easily overlaid by Events when the window isn't 'large'.  Changing it to 2 ensures that the widest number possible (255.255.255.255) isn't hidden at all.