### PR TITLE
Unselect events after action in Events view

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -236,24 +236,18 @@ controllerModule.controller('events', ['clientsService', 'conf', '$cookieStore',
       });
     };
 
-    $scope.unselectEvents = function(events) {
-      _.each(events, function (event) {
-        event.selected = false;
-      });
-    }
-
     $scope.resolveEvents = function(events) {
       var selectedEvents = helperService.selectedItems(events);
       _.each(selectedEvents, function(event) {
         $scope.resolveEvent(event.dc, event.client, event.check);
       });
-      $scope.unselectEvents(selectedEvents);
+      helperService.unselectItems(selectedEvents);
     };
 
     $scope.silenceEvents = function($event, events) {
       var selectedEvents = helperService.selectedItems(events);
       $scope.stash($event, selectedEvents);
-      $scope.unselectEvents(selectedEvents);
+      helperService.unselectItems(selectedEvents);
     };
 
     $scope.$watch('filters.q', function(newVal) {

--- a/js/controllers.js
+++ b/js/controllers.js
@@ -236,16 +236,24 @@ controllerModule.controller('events', ['clientsService', 'conf', '$cookieStore',
       });
     };
 
+    $scope.unselectEvents = function(events) {
+      _.each(events, function (event) {
+        event.selected = false;
+      });
+    }
+
     $scope.resolveEvents = function(events) {
       var selectedEvents = helperService.selectedItems(events);
       _.each(selectedEvents, function(event) {
         $scope.resolveEvent(event.dc, event.client, event.check);
       });
+      $scope.unselectEvents(selectedEvents);
     };
 
     $scope.silenceEvents = function($event, events) {
       var selectedEvents = helperService.selectedItems(events);
       $scope.stash($event, selectedEvents);
+      $scope.unselectEvents(selectedEvents);
     };
 
     $scope.$watch('filters.q', function(newVal) {

--- a/js/services.js
+++ b/js/services.js
@@ -397,6 +397,13 @@ serviceModule.service('helperService', function() {
       return item.selected === true;
     });
   };
+  this.unselectItems = function(items) {
+    _.each(items, function(item) {
+      if (item.selected === true) {
+        item.selected = false;
+      }
+    });
+  };
 });
 
 /**


### PR DESCRIPTION
This is intended to fix to https://github.com/sensu/uchiwa/issues/258.

This PR adds ```unselectEvents()```, which sets ```event.selected``` to ```false``` for each event in an array of events. ```resolveEvents()``` and ```silenceEvents()``` have been updated to call ```unselectEvents(selectedEvents)``` to ensure that events are properly unselected after an action is performed on them.