### PR TITLE
Sort clients by Status and Name

### DIFF
--- a/partials/views/clients.html
+++ b/partials/views/clients.html
@@ -42,7 +42,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr ng-repeat="client in clients | orderBy:predicate:reverse | collection:'clients' | filter:filters.q | filter:{dc:filters.dc} | filterSubscriptions:filters.subscription | limitTo:filters.limit track by $index" ng-click="go('/client/'+client.dc+'/'+client.name)">
+              <tr ng-repeat="client in clients | orderBy:['name', 'status'] | orderBy:predicate:reverse | collection:'clients' | filter:filters.q | filter:{dc:filters.dc} | filterSubscriptions:filters.subscription | limitTo:filters.limit track by $index" ng-click="go('/client/'+client.dc+'/'+client.name)">
                 <td class="well-{{ client.status | getStatusClass }}" ng-click="$event.stopPropagation()">
                   <input type="checkbox" ng-model="client.selected" = ng-if="user.canPost()"></input>
                 </td>


### PR DESCRIPTION
This will sort the Clients page first by the Status (Green is at the bottom), and then by Name within each Status. Addresses https://github.com/sensu/uchiwa/issues/267