### PR TITLE
Fix stash expiration timestamp in Stashes view

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -101,7 +101,7 @@ filterModule.filter('getExpireTimestamp', ['conf', function (conf) {
     if (stash.expire === -1) {
       return 'Never';
     }
-    var expiration = (stash.content.timestamp + stash.expire) * 1000;
+    var expiration = (moment().unix() + stash.expire) * 1000;
     return moment(expiration).format(conf.date);
   };
 }]);


### PR DESCRIPTION
This PR is intended to fix https://github.com/sensu/uchiwa/issues/278

Update getExpireTimestamp filter to calculate the expiration based on the current time, rather than the timestamp embedded in the stash's contents.

The tests still for this filter still work, though the setting of { content: { timestamp: } } is now extraneous.

As per my comments on https://github.com/sensu/uchiwa/issues/278, this is based on the assumption that the expire value returned from the Sensu API still represents the same value in Sensu > 0.13.1 as it does in 0.13.1. Currently, I don't have a newer Sensu environment against which to test.