### PR TITLE
Show relative times for events

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "angular": "~1.3.13",
     "angular-bootstrap": "0.11.0",
     "angular-cookies": "~1.3.13",
+    "angular-moment": "~0.9.0",
     "angular-route": "~1.3.13",
     "angular-sanitize": "~1.3.13",
     "angular-toastr": "0.5.2",

--- a/js/app.js
+++ b/js/app.js
@@ -13,6 +13,7 @@ angular.module('uchiwa', [
   'ngRoute',
   'ngSanitize',
   // 3rd party dependencies
+  'angularMoment',
   'toastr',
   'ui.bootstrap'
 ]);

--- a/partials/views/events.html
+++ b/partials/views/events.html
@@ -63,7 +63,9 @@
                 <td class="output" ng-bind-html="event.check.output | linky" ng-click="helpers.openLink($event)"></td>
                 <td>{{ event.occurrences }}</td>
                 <td>{{ event.dc }}</td>
-                <td>{{ event.check.issued | getTimestamp }}</td>
+                <td tooltip-placement="top" tooltip-trigger tooltip-html-unsafe="Local Time<br /><small>{{ event.check.issued | getTimestamp }}</small>">
+                  <span am-time-ago="event.check.issued" am-preprocess="unix"></span>
+                </td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
When working across multiple timezones, it can be confusing to figure out when an event actually came in. This change shows how long it's been since the event was issued:

![screen shot 2015-03-13 at 10 44 23 pm](https://cloud.githubusercontent.com/assets/465717/6648943/abcc0cfc-c9d8-11e4-8832-0f3b37f0e31b.png)

The issue time can be seen via the tooltip.