### PR TITLE
Truncate the source with ellipsis

### DIFF
--- a/css/uchiwa-dark/uchiwa-dark.css
+++ b/css/uchiwa-dark/uchiwa-dark.css
@@ -972,6 +972,11 @@ li.timestamp .relative-timestamp {
   overflow: hidden;
   white-space: nowrap; }
 
+.table td.source {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap; }
+
 .table td.output {
   text-overflow: ellipsis;
   overflow: hidden;

--- a/css/uchiwa-default/uchiwa-default.css
+++ b/css/uchiwa-default/uchiwa-default.css
@@ -959,6 +959,11 @@ li.timestamp .relative-timestamp {
   overflow: hidden;
   white-space: nowrap; }
 
+.table td.source {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap; }
+
 .table td.output {
   text-overflow: ellipsis;
   overflow: hidden;

--- a/partials/views/events.html
+++ b/partials/views/events.html
@@ -48,7 +48,7 @@
                 <td class="well-{{ event.check.status | getStatusClass }}" ng-click="$event.stopPropagation()">
                   <input type="checkbox" ng-model="event.selected" ng-if="user.canPost()"></input>
                 </td>
-                <td>
+                <td class="source">
                   <span ng-click="event.client['dc'] = event.dc; stash($event, event.client)" ng-if="user.canPost()">
                     <i class="fa fa-fw {{ event.client.acknowledged | getAckClass }}"></i>
                   </span>


### PR DESCRIPTION
For very long client names use ellipsis so the page doesn't go crazy.