### PR TITLE
Order events by most recent

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -191,7 +191,7 @@ controllerModule.controller('events', ['clientsService', 'conf', '$cookieStore',
     $scope.pageHeaderText = 'Events';
     titleFactory.set($scope.pageHeaderText);
 
-    $scope.predicate = '-check.status';
+    $scope.predicate = ['-check.status', '-check.issued'];
     $scope.filters = {};
 
     // Routing


### PR DESCRIPTION
Makes sense to me that events should show the newest events by default. This makes it more useful to have on a TV screen for example.