### PR TITLE
Client tags

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -219,6 +219,15 @@ filterModule.filter('richOutput', ['$filter', function($filter) {
   };
 }]);
 
+filterModule.filter('replaceSpaces', function() {
+  return function(tag) {
+    if (!tag) {
+      return tag;
+    }
+    return tag.replace(/\s+/g, '_');
+  };
+});
+
 filterModule.filter('setMissingProperty', function() {
   return function(property) {
     return property || false;

--- a/js/services.js
+++ b/js/services.js
@@ -92,6 +92,7 @@ serviceModule.service('backendService', ['conf', '$http', '$interval', '$locatio
 
         $rootScope.stashes = data.Stashes;
         $rootScope.subscriptions = data.Subscriptions;
+        $rootScope.tags = data.Tags.sort();
 
         $timeout(function() {
           $rootScope.$broadcast('sensu');

--- a/partials/panel/tags.html
+++ b/partials/panel/tags.html
@@ -1,0 +1,31 @@
+<div class="dropdown">
+  <span dropdown-toggle class="action" ng-if="filters.dc == ''">
+    Tags <i class="fa fa-caret-down"></i>
+  </span>
+  <span dropdown-toggle class="action" ng-if="filters.dc != ''">
+    {{filters.dc}} <i class="fa fa-caret-down"></i>
+  </span>
+  <ul class="dropdown-menu">
+    <li ng-class="{selected: $cookies.get('source') || true}">
+      <input type="checkbox" ng-model="checked_source" ng-checked="true"/> Source
+    </li>
+    <li ng-class="{selected: $cookies.get('check') || true}">
+      <input type="checkbox" ng-model="checked_check" ng-checked="true"/> Check
+    </li>
+    <li ng-class="{selected: $cookies.get('output') || true}">
+      <input type="checkbox" ng-model="checked_output" ng-checked="true"/> Output
+    </li>
+    <li ng-class="{selected: $cookies.get('occurances') || true}">
+      <input type="checkbox" ng-model="checked_occurances" ng-checked="true"/> Occurances
+    </li>
+    <li ng-class="{selected: $cookies.get('DC') || true}">
+      <input type="checkbox" ng-model="checked_dc" ng-checked="true"/> DC
+    </li>
+    <li ng-class="{selected: $cookies.get('issued') || true}">
+      <input type="checkbox" ng-model="checked_issued" ng-checked="true"/> Issued
+    </li>
+    <li ng-repeat="tag in tags " ng-class="{selected: false}">
+      <input type="checkbox" ng-checked="true"/> {{ tag }}
+    </li>
+  </ul>
+</div>

--- a/partials/views/events.html
+++ b/partials/views/events.html
@@ -13,6 +13,8 @@
               <ng-include src="partialsPath + '/panel/breadcrumb.html'"></ng-include>
             </div>
             <div class="col-xs-12 nopadding">
+              <! --tags-->
+              <ng-include src="partialsPath + '/panel/tags.html'"></ng-include>
               <! --dc-->
               <ng-include src="partialsPath + '/panel/dc.html'"></ng-include>
               <! --actions-->
@@ -37,21 +39,21 @@
                 </th>
                 <th class="col-sm-3" ng-click="predicate = 'sourceName'; reverse=!reverse">Source <i class="fa fa-sort"></i></th>
                 <th class="col-sm-3" ng-click="predicate = 'check.name'; reverse=!reverse">Check <i class="fa fa-sort"></i></th>
-                <th class="col-sm-4" ng-click="predicate = 'check.output'; reverse=!reverse">Output <i class="fa fa-sort"></i></th>
+                <th class="col-sm-3" ng-click="predicate = 'check.output'; reverse=!reverse">Output <i class="fa fa-sort"></i></th>
                 <th class="col-sm-1" ng-click="predicate = 'occurrences'; reverse=!reverse"><i class="fa fa-slack" tooltip-placement="top" tooltip-trigger tooltip="Occurrences"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-dc" ng-click="predicate = 'dc'; reverse=!reverse"><i class="fa fa-cloud" tooltip-placement="top" tooltip-trigger tooltip="Datacenter"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-date" ng-click="predicate = 'check.issued'; reverse=!reverse"><i class='fa fa-clock-o' tooltip-placement="top" tooltip-trigger tooltip="Issued"></i> <i class="fa fa-sort"></i></th>
               </tr>
             </thead>
             <tbody>
-              <tr ng-repeat="event in events | buildEvents | orderBy:predicate:reverse | collection:'events' | filter:filters.q | filter:{dc:filters.dc} | hideSilenced:filters.silenced | hideClientSilenced:filters.clientSilenced | hideOccurrences:filters.occurrences | limitTo:filters.limit track by event._id" ng-click="go('/client/'+event.dc+'/'+event.client.name+'?check='+event.check.name)">
+              <tr ng-repeat="event in events | buildEvents | orderBy:predicate:reverse | collection:'events' | filter:filters.q | filter:{dc:filters.dc} | hideSilenced:filters.silenced | hideClientSilenced:filters.clientSilenced | hideOccurrences:filters.occurrences | limitTo:filters.limit track by $index" ng-click="go('/client/'+event.dc+'/'+event.client.name+'?check='+event.check.name)">
                 <td class="well-{{ event.check.status | getStatusClass }}" ng-click="$event.stopPropagation()">
                   <input type="checkbox" ng-model="event.selected" ng-if="user.canPost()"></input>
-                </td>
-                <td>
                   <span ng-click="event.client['dc'] = event.dc; stash($event, event.client)" ng-if="user.canPost()">
                     <i class="fa fa-fw {{ event.client.acknowledged | getAckClass }}"></i>
                   </span>
+                </td>
+                <td>
                   <span class="dropdown-toggle" >{{ event.sourceName }}</span>
                 </td>
                 <td class="main">
@@ -60,7 +62,7 @@
                   </span>
                   <span class="main check-name" tooltip-placement="top" tooltip-trigger tooltip-html-unsafe="Subscriptions<br /><small>{{event.check.subscribers|arrayToString}}</small>">{{ event.check.name }}</span>
                 </td>
-                <td class="output" ng-bind-html="event.check.output | linky" ng-click="helpers.openLink($event)"></td>
+                <td ng-bind-html="event.check.output | linky" ng-click="helpers.openLink($event)"></td>
                 <td>{{ event.occurrences }}</td>
                 <td>{{ event.dc }}</td>
                 <td tooltip-placement="top" tooltip-trigger tooltip-html-unsafe="Local Time<br /><small>{{ event.check.issued | getTimestamp }}</small>">

--- a/partials/views/events.html
+++ b/partials/views/events.html
@@ -39,7 +39,7 @@
                 </th>
                 <th class="col-sm-3" ng-click="predicate = 'sourceName'; reverse=!reverse">Source <i class="fa fa-sort"></i></th>
                 <th class="col-sm-3" ng-click="predicate = 'check.name'; reverse=!reverse">Check <i class="fa fa-sort"></i></th>
-                <th class="col-sm-3" ng-click="predicate = 'check.output'; reverse=!reverse">Output <i class="fa fa-sort"></i></th>
+                <th class="col-sm-4" ng-click="predicate = 'check.output'; reverse=!reverse">Output <i class="fa fa-sort"></i></th>
                 <th class="col-sm-1" ng-click="predicate = 'occurrences'; reverse=!reverse"><i class="fa fa-slack" tooltip-placement="top" tooltip-trigger tooltip="Occurrences"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-dc" ng-click="predicate = 'dc'; reverse=!reverse"><i class="fa fa-cloud" tooltip-placement="top" tooltip-trigger tooltip="Datacenter"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-date" ng-click="predicate = 'check.issued'; reverse=!reverse"><i class='fa fa-clock-o' tooltip-placement="top" tooltip-trigger tooltip="Issued"></i> <i class="fa fa-sort"></i></th>
@@ -62,7 +62,7 @@
                   </span>
                   <span class="main check-name" tooltip-placement="top" tooltip-trigger tooltip-html-unsafe="Subscriptions<br /><small>{{event.check.subscribers|arrayToString}}</small>">{{ event.check.name }}</span>
                 </td>
-                <td ng-bind-html="event.check.output | linky" ng-click="helpers.openLink($event)"></td>
+                <td class="output" ng-bind-html="event.check.output | linky" ng-click="helpers.openLink($event)"></td>
                 <td>{{ event.occurrences }}</td>
                 <td>{{ event.dc }}</td>
                 <td tooltip-placement="top" tooltip-trigger tooltip-html-unsafe="Local Time<br /><small>{{ event.check.issued | getTimestamp }}</small>">


### PR DESCRIPTION
This adds a concept of tags to clients that are added to Sensu. 

By adding a new hash called tags under the client heading in on each client's config, you can add more data to Uchiwa for sorting and filtering.

```
tags
{
  "Data Center": "us-west-2",
  "Distro Codename": "trusty",
  "Distro ID": "Ubuntu",
  "Distro Release": "14.04",
  "Domain": "local",
  "Environment": "dev",
  "FQDN": "web1.local",
  "Hostname": "web1",
  "Region": "uswest2"
}
```

There'll be further work to make the tags viewable/sortable. This can also be used for creating shareable dashboards.

This is required to get it running:
https://github.com/sensu/uchiwa/pull/306
