### PR TITLE
Add empty output when a client switch to status '0'

### DIFF
--- a/js/services.js
+++ b/js/services.js
@@ -72,7 +72,10 @@ serviceModule.service('backendService', ['conf', '$http', '$interval', '$locatio
 
         $rootScope.clients = _.map(data.Clients, function(client) {
           var existingClient = _.findWhere($rootScope.clients, {name: client.name, dc: client.dc});
-          if (existingClient !== undefined) {
+          if (angular.isDefined(existingClient)) {
+            if (angular.isUndefined(client.output) && angular.isDefined(existingClient.output)) {
+              client.output = '';
+            }
             client = angular.extend(existingClient, client);
           }
           return existingClient || client;


### PR DESCRIPTION
Fix https://github.com/sensu/uchiwa/issues/309

The `client.output` attribute is undefined when `client.status === 0` so if `existingClient.output` was already defined, it does not get replaced.

CC @amdprophet 