### PR TITLE
Only get the timestamp if it exists

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -185,7 +185,9 @@ controllerModule.controller('ClientController', ['backendService', 'clientsServi
         // apply filters
         var images = [];
         angular.forEach(check.last_result, function(value, key) { // jshint ignore:line
-          value = $filter('getTimestamp')(value);
+          if (value) {
+            value = $filter('getTimestamp')(value);
+          }
           value = $filter('richOutput')(value);
 
           if (/<img src=/.test(value)) {


### PR DESCRIPTION
JIT clients (https://sensuapp.org/docs/0.20/clients#jit-clients) don't have timestamps. If you try to load a check that belongs to a JIT client, the getTimestamp function will fail because the timestamp value is null.