### PR TITLE
We emit a signal so that it can be displayed as popup instead of a console.error

### DIFF
--- a/js/services.js
+++ b/js/services.js
@@ -78,8 +78,8 @@ serviceModule.service('backendService', ['audit', 'conf', '$http', '$interval', 
         .success(function(data) {
           $rootScope.health = data;
         })
-        .error(function(error) {
-          console.error(JSON.stringify(error));
+        .error(function() {
+          $rootScope.$emit('notification', 'error', 'Unable to get health.');
         });
     };
     this.getMetrics = function() {
@@ -87,9 +87,9 @@ serviceModule.service('backendService', ['audit', 'conf', '$http', '$interval', 
         .success(function(data) {
           $rootScope.metrics = data;
         })
-        .error(function(error) {
+        .error(function() {
           $rootScope.metrics = {aggregates: {total: 0}, checks: {total: 0}, clients: {critical: 0, total: 0, unknown: 0, warning: 0}, datacenters: {total: 0}, events: {critical: 0, total: 0, unknown: 0, warning: 0}, stashes: {total: 0}};
-          console.error(JSON.stringify(error));
+          $rootScope.$emit('notification', 'error', 'Unable to get metrics.');
         });
     };
     this.getSEMetrics = function(endpoint) {

--- a/test/karma/services-spec.js
+++ b/test/karma/services-spec.js
@@ -3,13 +3,39 @@
 describe('services', function () {
   var $rootScope;
   var $scope;
+  var $httpBackend;
 
   beforeEach(module('uchiwa'));
-  beforeEach(inject(function (_$rootScope_) {
+  beforeEach(inject(function (_$rootScope_, _$httpBackend_) {
+    $httpBackend = _$httpBackend_;
     $rootScope = _$rootScope_;
     $scope = $rootScope.$new();
+    $httpBackend.expect('GET', 'config').respond(200, {Uchiwa:{Refresh: 10}});
   }));
 
+  describe('backendService', function () {
+    describe('getHealth', function() {
+      it('emit a signal when health endpoint is down', inject(function(backendService) {
+	  spyOn($rootScope, "$emit");
+	  $httpBackend.expect('GET', 'health').respond(500, 'error');
+          backendService.getHealth();
+	  $httpBackend.flush();
+	  expect($rootScope.$emit).toHaveBeenCalledWith("notification", "error", "Unable to get health.");
+          $httpBackend.verifyNoOutstandingExpectation();
+          $httpBackend.verifyNoOutstandingRequest();
+	}));
+
+      it('emit a signal when metrics endpoint is down', inject(function(backendService) {
+	  spyOn($rootScope, "$emit");
+	  $httpBackend.expect('GET', 'metrics').respond(500, 'error');
+          backendService.getMetrics();
+	  $httpBackend.flush();
+	  expect($rootScope.$emit).toHaveBeenCalledWith("notification", "error", "Unable to get metrics.");
+          $httpBackend.verifyNoOutstandingExpectation();
+          $httpBackend.verifyNoOutstandingRequest();
+	}));
+    });
+  });
   describe('clientsService', function () {
     describe('searchCheckHistory()', function() {
       it('returns the right check from the client history', inject(function (clientsService) {


### PR DESCRIPTION
I was tempted to remove line #91 so that the metrics stays as last "polled" but I guess if it was done like that there was a reason?