### PR TITLE
a "query language" for search.

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -401,12 +401,20 @@ controllerModule.controller('EventsController', ['clientsService', 'conf', '$coo
 
     var updateFilters = function() {
       var filtered = $filter('filter')($scope.events, {dc: $scope.filters.dc}, $scope.filterComparator);
+      var q = $scope.filters.q;
+
+      try {
+        q = angular.fromJson(q);
+      } catch(e) {
+        console.log('fail', e.message);
+      }
+
       filtered = $filter('filter')(filtered, {check: {status: $scope.filters.status}});
       filtered = $filter('hideSilenced')(filtered, $scope.filters.silenced);
       filtered = $filter('hideClientsSilenced')(filtered, $scope.filters.clientsSilenced);
       filtered = $filter('hideOccurrences')(filtered, $scope.filters.occurrences);
       filtered = $filter('filter')(filtered, $scope.filters.check);
-      filtered = $filter('filter')(filtered, $scope.filters.q);
+      filtered = $filter('filter')(filtered, q);
       filtered = $filter('collection')(filtered, 'events');
       $scope.filtered = filtered;
     };


### PR DESCRIPTION
this is just for demonstration and discussion.

it would be nice if the search box had some form of query language
that allowed you to filter any uchiwa page with more specific matches
on the rich metadata available in sensu events.

I envision doing this by supporting some kind of generic query language
as a filter. In this example we just use angular $filter's support for
an object as the query langage.   enabling searches of the form:

  `{"client": {"my_special_tag": "thing" }}`

to match events who's client data have the property "my_special_tag"
with values containing "thing" see: https://docs.angularjs.org/api/ng/filter/filter

ideally we'd use some other preexisting slicker query language.  suggestions?

This commit is just a demo of the idea.  the final product should
have the slick query language. and more importantly implement the filter
in all appropriate controllers and not just events.

Thoughts? suggestions?
