### PR TITLE
last_ok: display on events page.

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -19,7 +19,32 @@ filterModule.filter('arrayToString', function() {
 });
 
 filterModule.filter('buildEvents', function() {
+  function estimateLastOk(event) {
+    var check       = event.check,
+        output      = check.output,
+        occurrences = event.occurrences,
+        timestamp   = event.timestamp || check.timestamp,
+        interval    = check.interval,
+        age,
+        match;
+
+    if (interval) {
+      age = occurrences * interval;
+    } else if (check.name === 'keepalive') {
+      match = output && output.match(/\d+/);
+      age = match && parseInt(match);
+    }
+
+    if (isNaN(age) || isNaN(timestamp)) {
+      return;
+    }
+
+    return timestamp - age;
+  }
+
   return function(events) {
+    var lastOk;
+
     if (Object.prototype.toString.call(events) !== '[object Array]') {
       return events;
     }
@@ -35,6 +60,12 @@ filterModule.filter('buildEvents', function() {
         event.check = {};
       }
       event.sourceName = event.check.source || event.client.name;
+      if (!('last_ok' in event)) {
+        lastOk = estimateLastOk(event);
+        /* jshint -W106  */
+        if (lastOk) { event.last_ok = lastOk; }
+        /* jshint +W106 */
+      }
     });
     return events;
   };

--- a/js/filters.js
+++ b/js/filters.js
@@ -60,12 +60,12 @@ filterModule.filter('buildEvents', function() {
         event.check = {};
       }
       event.sourceName = event.check.source || event.client.name;
-      if (!('last_ok' in event)) {
+      /* jshint -W106  */
+      if (!('last_ok' in event) || event.last_ok === null) {
         lastOk = estimateLastOk(event);
-        /* jshint -W106  */
         if (lastOk) { event.last_ok = lastOk; }
-        /* jshint +W106 */
       }
+      /* jshint +W106 */
     });
     return events;
   };

--- a/partials/views/events.html
+++ b/partials/views/events.html
@@ -43,6 +43,7 @@
                 <th class="col-sm-1" ng-click="predicate = 'occurrences'; reverse=!reverse"><i class="fa fa-slack" tooltip-placement="top" tooltip-trigger tooltip="Occurrences"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-dc" ng-click="predicate = 'dc'; reverse=!reverse"><i class="fa fa-cloud" tooltip-placement="top" tooltip-trigger tooltip="Datacenter"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-date" ng-click="predicate = 'check.issued'; reverse=!reverse"><i class='fa fa-clock-o' tooltip-placement="top" tooltip-trigger tooltip="Issued"></i> <i class="fa fa-sort"></i></th>
+                <th class="col-sm-1" ng-click="predicate = 'last_ok'; reverse=!reverse"><i class="fa fa-calendar" tooltip-placement="top" tooltip-trigger tooltip="Last Ok"></i> <i class="fa fa-sort"></i></th>
               </tr>
             </thead>
             <tbody>
@@ -68,6 +69,9 @@
                 <td class="dc">{{ event.dc }}</td>
                 <td>
                   <relative-time timestamp="event.check.issued"></relative-time>
+                </td>
+                <td>
+                  <relative-time timestamp="event.last_ok"></relative-time>
                 </td>
               </tr>
             </tbody>

--- a/test/karma/filters-spec.js
+++ b/test/karma/filters-spec.js
@@ -99,6 +99,16 @@ describe('filters', function () {
         timestamp: 1465161618
       };
 
+      var event_with_null_last_ok = {
+        check: {
+          interval: 240,
+          timestamp: 1465161200
+        },
+        occurrences: 5,
+        client: { name: 'baz'},
+        last_ok: null
+      };
+
       var event_with_interval_and_occurences = {
         check: {
           interval: 240,
@@ -111,6 +121,7 @@ describe('filters', function () {
       expect(lastOkOf(event_with_last_ok)).toEqual(1465161618);
       expect(lastOkOf(event_with_keepalive)).toEqual(1464874088);
       expect(lastOkOf(event_with_interval_and_occurences)).toEqual(1465160000);
+      expect(lastOkOf(event_with_null_last_ok)).toEqual(1465160000);
     }));
 
   });

--- a/test/karma/filters-spec.js
+++ b/test/karma/filters-spec.js
@@ -80,6 +80,39 @@ describe('filters', function () {
       expect(buildEventsFilter(events)).toEqual(expectedEvents);
     }));
 
+    it("adds last_ok if it's missing", inject(function (buildEventsFilter) {
+      function lastOkOf(event) {
+        return buildEventsFilter([event])[0].last_ok
+      }
+
+      var event_with_last_ok = {
+        check: { source: 'foo' },
+        last_ok: 1465161618
+      };
+
+      var event_with_keepalive = {
+        check: {
+          source: 'bar',
+          name: 'keepalive',
+          output: "No keepalive sent from client for 287530 seconds (>=180)",
+        },
+        timestamp: 1465161618
+      };
+
+      var event_with_interval_and_occurences = {
+        check: {
+          interval: 240,
+          timestamp: 1465161200
+        },
+        occurrences: 5,
+        client: { name: 'baz'},
+      };
+
+      expect(lastOkOf(event_with_last_ok)).toEqual(1465161618);
+      expect(lastOkOf(event_with_keepalive)).toEqual(1464874088);
+      expect(lastOkOf(event_with_interval_and_occurences)).toEqual(1465160000);
+    }));
+
   });
 
   describe('buildStashes', function () {


### PR DESCRIPTION
feedback welcome.

sensu events in 0.24+ contain a last_ok timestamp.  https://github.com/sensu/sensu/commit/004accc3

this PR adds display of that to the events view. 

it also estimates the last_ok timestamp if the event is a keepalive event
or if the event is from an older sensu-server and doesn't yet have the last_ok
property. 

in our organization people often mistakenly assume the "issued" timestamp
is how long ago the check started failing, showing this last_ok value should
mitigate that.


![image](https://cloud.githubusercontent.com/assets/1090063/15918964/8fb65ab0-2dc1-11e6-9426-00d4d903f3eb.png)

[ zomg 23 days! ] 
