### PR TITLE
fix invisible 'number of items' in search bar

### DIFF
--- a/css/uchiwa-dark/uchiwa-dark.css
+++ b/css/uchiwa-dark/uchiwa-dark.css
@@ -1002,7 +1002,7 @@ li.timestamp .relative-timestamp {
   font-size: 22px; }
 
 .search-results {
-  color: #FFFFFF;
+  color: #4D4D4D;
   position: absolute;
   height: auto;
   top: 0;


### PR DESCRIPTION
This fixes invisible 'number of items' in search bar, in uchiwa-dark theme

[uchiwa/issues/532](https://github.com/sensu/uchiwa/issues/532)