### PR TITLE
customize the 'create silence' page via config

### DIFF
--- a/partials/modals/create-silenced.html
+++ b/partials/modals/create-silenced.html
@@ -31,7 +31,7 @@
     <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="3600">1 hour</label>
     <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="86400">24 hours</label>
     <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="'custom'">Custom</label>
-    <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="-1">No expiration</label>
+    <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="-1" ng-hide="config.Uchiwa.DisableNoExpiration">No expiration</label>
   </div>
 
   <div ng-show="options.expire === 'custom'">
@@ -43,7 +43,7 @@
   <div style="clear:both">
     <div class="checkbox">
       <label>
-        <input type="checkbox" ng-model="options.expire_on_resolve"> Expire on Resolve
+        <input type="checkbox" ng-model="options.expire_on_resolve" ng-init="options.expire_on_resolve=config.Uchiwa.ExpireOnResolveDefault"> Expire on Resolve
       </label>
     </div>
   </div>

--- a/partials/modals/create-silenced.html
+++ b/partials/modals/create-silenced.html
@@ -31,7 +31,7 @@
     <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="3600">1 hour</label>
     <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="86400">24 hours</label>
     <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="'custom'">Custom</label>
-    <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="-1" ng-hide="config.Uchiwa.DisableNoExpiration">No expiration</label>
+    <label class="btn btn-xs btn-default" ng-model="options.expire" btn-radio="-1" ng-hide="config.Uchiwa.UserOptions.DisableNoExpiration">No expiration</label>
   </div>
 
   <div ng-show="options.expire === 'custom'">
@@ -43,7 +43,7 @@
   <div style="clear:both">
     <div class="checkbox">
       <label>
-        <input type="checkbox" ng-model="options.expire_on_resolve" ng-init="options.expire_on_resolve=config.Uchiwa.ExpireOnResolveDefault"> Expire on Resolve
+        <input type="checkbox" ng-model="options.expire_on_resolve" ng-init="options.expire_on_resolve=config.Uchiwa.UserOptions.ExpireOnResolveDefault"> Expire on Resolve
       </label>
     </div>
   </div>


### PR DESCRIPTION
This commit hides the "No Expiration" selection and checks by default
the "Expire on Resolve" box inside the silence creation popup based upon
the config values introduced in sensu/uchiwa#584

Addresses sensu/uchiwa#531 and sensu/uchiwa#538
Requires sensu/uchiwa#584
