### PR TITLE
Add Environment column to clients and events

### DIFF
--- a/partials/views/clients.html
+++ b/partials/views/clients.html
@@ -39,6 +39,7 @@
                 <th class="col-min" ng-if="!user.isReadOnly()"></th>
                 <th class="col-sm-2" ng-click="predicate = 'name'; reverse=!reverse">Name <i class="fa fa-sort"></i></th>
                 <th class="col-sm-2" ng-click="predicate = 'address'; reverse=!reverse">IP <i class="fa fa-sort"></i></th>
+                <th class="col-sm-2" ng-click="predicate = 'environment'; reverse=!reverse">Environment <i class="fa fa-sort"></i></th>
                 <th class="col-sm-5" ng-click="predicate = 'output'; reverse=!reverse">Events <i class="fa fa-sort"></i></th>
                 <th class="col-dc" ng-click="predicate = 'dc'; reverse=!reverse"><i class="fa fa-cloud" tooltip-placement="top" tooltip-trigger uib-tooltip="Datacenter"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-dc" ng-click="predicate = 'version'; reverse=!reverse"><i class="fa fa-upload" tooltip-placement="top" tooltip-trigger uib-tooltip="Sensu Version"></i> <i class="fa fa-sort"></i></th>
@@ -55,6 +56,7 @@
                 </td>
                 <td class="main"><span tooltip-placement="top" tooltip-trigger tooltip-html="'Subscriptions<br /><small>{{client.subscriptions|arrayToString}}</small>'">{{ client.name }}</span></td>
                 <td>{{ client.address }}</td>
+                <td>{{ client.environment }}</td>
                 <td class="output" ng-bind-html="client.output | linky" ng-click="openLink($event)"></td>
                 <td class="dc">{{ client.dc }}</td>
                 <td>{{ client.version }}</td>

--- a/partials/views/events.html
+++ b/partials/views/events.html
@@ -40,6 +40,7 @@
                 <th class="col-sm-3" ng-click="predicate = 'sourceName'; reverse=!reverse">Source <i class="fa fa-sort"></i></th>
                 <th class="col-sm-3" ng-click="predicate = 'check.name'; reverse=!reverse">Check <i class="fa fa-sort"></i></th>
                 <th class="col-sm-4" ng-click="predicate = 'check.output'; reverse=!reverse">Output <i class="fa fa-sort"></i></th>
+                <th class="col-sm-4" ng-click="predicate = 'check.environment'; reverse=!reverse">Environment <i class="fa fa-sort"></i></th>
                 <th class="col-sm-1" ng-click="predicate = 'occurrences'; reverse=!reverse"><i class="fa fa-slack" tooltip-placement="top" tooltip-trigger uib-tooltip="Occurrences"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-dc" ng-click="predicate = 'dc'; reverse=!reverse"><i class="fa fa-cloud" tooltip-placement="top" tooltip-trigger uib-tooltip="Datacenter"></i> <i class="fa fa-sort"></i></th>
                 <th class="col-date" ng-click="predicate = 'check.issued'; reverse=!reverse"><i class='fa fa-hourglass-start' tooltip-placement="top" tooltip-trigger uib-tooltip="Issued"></i> <i class="fa fa-sort"></i></th>
@@ -65,6 +66,7 @@
                   <span class="main check-name" tooltip-placement="top" tooltip-trigger tooltip-html="'Subscriptions<br /><small>{{event.check.subscribers|arrayToString}}</small>'">{{ event.check.name }}</span>
                 </td>
                 <td class="output" ng-bind-html="event.check.output | linky" ng-click="openLink($event)"></td>
+                <td>{{event.environment}}</td>
                 <td>{{ event.occurrences }}</td>
                 <td class="dc">{{ event.dc }}</td>
                 <td>


### PR DESCRIPTION
Would there be sufficient reason to add an environment column globally?

If not, I'll keep this in my own fork for my own usage and work on a more generic version.