### PR TITLE
Fix blank events in first login

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -685,7 +685,7 @@ controllerModule.controller('LoginController', ['Config', '$cookieStore', '$loca
       login.$save()
         .then(function() {
           User.set();
-          $location.path('/events');
+          $location.path('/events').search({status: null});
         },
         function(error) {
           console.error(error);


### PR DESCRIPTION
In the #155 commit, there is a missing cleanup "status=unauthorized"