### PR TITLE
Improve event status filtering by handling unknown statuses greater than 3

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -562,7 +562,7 @@ controllerModule.controller('EventsController', ['Clients', 'Events', '$filter',
 
     var updateFilters = function() {
       var filtered = $filter('filter')($scope.events, {dc: $scope.filters.dc}, Helpers.equals);
-      filtered = $filter('filter')(filtered, {check: {status: $scope.filters.status}});
+      filtered = $filter('status')(filtered, $scope.filters.status);
       filtered = $filter('hideSilenced')(filtered, $scope.filters.silenced);
       filtered = $filter('hideClientsSilenced')(filtered, $scope.filters.clientsSilenced);
       filtered = $filter('hideOccurrences')(filtered, $scope.filters.occurrences);

--- a/js/filters.js
+++ b/js/filters.js
@@ -208,6 +208,29 @@ filterModule.filter('hideSilenced', function() {
   };
 });
 
+filterModule.filter('status', function() {
+  return function(events, status) {
+    // Return all events if no status filter is set
+    if (status === '') {
+      return events;
+    }
+
+    status = parseInt(status);
+
+    // If the status is unknown return all statuses from 3 and up
+    if (status === 3) {
+      return events.filter(function (item) {
+        return item.check.status >= status;
+      });
+    }
+    else {
+      return events.filter(function (item) {
+        return item.check.status === status;
+      });
+    }
+  };
+});
+
 filterModule.filter('hideClientsSilenced', function() {
   return function(events, hideClientsSilenced) {
     if (Object.prototype.toString.call(events) !== '[object Array]') {

--- a/test/karma/filters-spec.js
+++ b/test/karma/filters-spec.js
@@ -312,6 +312,64 @@ describe('filters', function () {
     }));
   });
 
+  describe('status', function () {
+    it('returns all items if the status is empty', inject(function (statusFilter) {
+      var events = [
+        {id: 'foo', check: {status: 1}},
+        {id: 'bar', check: {status: 2}},
+        {id: 'baz', check: {status: 3}}
+      ];
+      expect(statusFilter(events, '')).toEqual(events);
+    }));
+    it('returns warnings if the status is 1', inject(function (statusFilter) {
+      var events = [
+        {id: 'foo', check: {status: 1}},
+        {id: 'bar', check: {status: 2}},
+        {id: 'baz', check: {status: 3}}
+      ];
+      var expectedEvents = [
+        {id: 'foo', check: {status: 1}}
+      ];
+      expect(statusFilter(events, '1')).toEqual(expectedEvents);
+    }));
+    it('returns criticals if the status is 2', inject(function (statusFilter) {
+      var events = [
+        {id: 'foo', check: {status: 1}},
+        {id: 'bar', check: {status: 2}},
+        {id: 'baz', check: {status: 3}}
+      ];
+      var expectedEvents = [
+        {id: 'bar', check: {status: 2}}
+      ];
+      expect(statusFilter(events, '2')).toEqual(expectedEvents);
+    }));
+    it('returns unknowns if the status is 3 or greater', inject(function (statusFilter) {
+      var events = [
+        {id: 'foo', check: {status: 1}},
+        {id: 'bar', check: {status: 2}},
+        {id: 'baz', check: {status: 3}},
+        {id: 'bax', check: {status: 4}},
+        {id: 'bax', check: {status: 1234123}}
+      ];
+      var expectedEvents = [
+        {id: 'baz', check: {status: 3}},
+        {id: 'bax', check: {status: 4}},
+        {id: 'bax', check: {status: 1234123}}
+      ];
+      expect(statusFilter(events, '3')).toEqual(expectedEvents);
+    }));
+    it('matches the status exactly rather than a fuzzy match', inject(function (statusFilter) {
+      var events = [
+        {id: 'foo', check: {status: 1111}},
+        {id: 'bar', check: {status: 1}}
+      ];
+      var expectedEvents = [
+        {id: 'bar', check: {status: 1}}
+      ];
+      expect(statusFilter(events, '1')).toEqual(expectedEvents);
+    }));
+  });
+
   describe('regex', function () {
     it('returns all items if the query is empty', inject(function (regexFilter) {
       var items = [{foo: 'bar'}];


### PR DESCRIPTION
This pull request improves the events filter by nicely handling events with statuses greater than 3. The current event filter for warnings and criticals will match any event that has a status with a 1 or 2 somewhere in it.  This behaviour was discovered when a bunch of windows servers were returning the status `3221225794` which conveniently matched all events filters because it contains a 1,2 and 3 :)

Before:

![image](https://user-images.githubusercontent.com/4550136/29867575-4d64deea-8d7c-11e7-8f41-3e94296ab9a2.png)
![image](https://user-images.githubusercontent.com/4550136/29867604-622d9556-8d7c-11e7-8a61-24fd91b1c216.png)
![image](https://user-images.githubusercontent.com/4550136/29867621-68bac5ec-8d7c-11e7-8095-7164a53260f0.png)
![image](https://user-images.githubusercontent.com/4550136/29867634-768881c8-8d7c-11e7-916b-3e235901a2d5.png)

After:
![image](https://user-images.githubusercontent.com/4550136/29867661-8ba465f4-8d7c-11e7-8109-1089e86d6655.png)
![image](https://user-images.githubusercontent.com/4550136/29867672-924f6d22-8d7c-11e7-9dfd-c0f4fc07ed64.png)
![image](https://user-images.githubusercontent.com/4550136/29867681-983363e2-8d7c-11e7-8099-593c65dfa3d9.png)
![image](https://user-images.githubusercontent.com/4550136/29867690-9f09896c-8d7c-11e7-84f8-a5911a733ec6.png)







