### PR TITLE
Unique check request

### DIFF
--- a/js/controllers.js
+++ b/js/controllers.js
@@ -311,7 +311,6 @@ controllerModule.controller('ClientController', ['Clients', 'Check', '$filter', 
     $scope.user = User;
     $scope.issueCheckRequest = function(dc, name, clientname) {
         var subscriber = ['client:'+clientname];
-        console.log('subscriber: '+subscriber);
         Check.issueCheckRequest(dc, name, subscriber);
     };
   }

--- a/js/controllers.js
+++ b/js/controllers.js
@@ -215,8 +215,8 @@ controllerModule.controller('ChecksController', ['Checks', '$filter', 'Helpers',
 /**
 * Client
 */
-controllerModule.controller('ClientController', ['Clients', '$filter', 'Helpers', '$location', '$rootScope', '$routeParams', 'routingService', '$scope', 'Sensu', 'Silenced', 'titleFactory', '$uibModal', 'User',
-  function (Clients, $filter, Helpers, $location, $rootScope, $routeParams, routingService, $scope, Sensu, Silenced, titleFactory, $uibModal, User) {
+controllerModule.controller('ClientController', ['Clients', 'Check', '$filter', 'Helpers', '$location', '$rootScope', '$routeParams', 'routingService', '$scope', 'Sensu', 'Silenced', 'titleFactory', '$uibModal', 'User',
+  function (Clients, Check, $filter, Helpers, $location, $rootScope, $routeParams, routingService, $scope, Sensu, Silenced, titleFactory, $uibModal, User) {
     $scope.predicate = '-last_status';
     $scope.reverse = false;
     $scope.check = null;
@@ -309,6 +309,11 @@ controllerModule.controller('ClientController', ['Clients', '$filter', 'Helpers'
     $scope.permalink = routingService.permalink;
     $scope.silence = Silenced.create;
     $scope.user = User;
+    $scope.issueCheckRequest = function(dc, name, clientname) {
+        var subscriber = ['client:'+clientname];
+        console.log('subscriber: '+subscriber);
+        Check.issueCheckRequest(dc, name, subscriber);
+    };
   }
 ]);
 

--- a/partials/views/client.html
+++ b/partials/views/client.html
@@ -88,6 +88,13 @@
                   </span>
                   <i class="fa fa-times" tooltip-placement="top" tooltip-trigger uib-tooltip="Delete Result" ng-click="deleteCheckResult(check.dc+'/'+client.name+'/'+check.check)"></i>
                   <i class="fa fa-check" tooltip-placement="top" tooltip-trigger uib-tooltip="Resolve" ng-click="resolveEvent(check.dc+'/'+client.name+'/'+check.check)" ng-if="check.last_status"></i>
+                  <i class="fa fa-refresh fa-fw"
+                    aria-hidden="true"
+                    tooltip-placement="top-right"
+                    tooltip-trigger
+                    uib-tooltip="Issue Request"
+                    ng-click="issueCheckRequest(check.dc, check.check, client.name)">
+                  </i>
                 </span>
               </div>
             </div>


### PR DESCRIPTION
add a new refresh button to the check-details view of a client
it forces a check request for **that check** on **that host**

it triggers a sensu-api /request with `{check: "checkname", dc: "sensu", subscribers: ["client:clientname"]}`

tested on uchiwa 0.25.3

fixes: https://github.com/sensu/uchiwa/issues/639