### PR TITLE
font: use a monospace font for ... monospace fonts

### DIFF
--- a/css/bootstrap-uchiwa/_variables.scss
+++ b/css/bootstrap-uchiwa/_variables.scss
@@ -43,7 +43,7 @@ $link-hover-color:      darken($link-color, 15%);
 $font-family-sans-serif:  'Roboto', sans-serif;
 $font-family-serif:       'Roboto', sans-serif;
 //** Default monospace fonts for `<code>`, `<kbd>`, and `<pre>`.
-$font-family-monospace:   'Roboto', sans-serif;
+$font-family-monospace:   monospace;
 $font-family-base:        $font-family-sans-serif;
 
 $font-size-base:          15px;


### PR DESCRIPTION
All the JSON settings displayed in Uchiwa are displayed with a sans-serif font, I believe it looks much better with a monospace font instead.

Sample: 
![screenshot from 2017-09-28 11-27-54](https://user-images.githubusercontent.com/65311/30959375-392d9c02-a440-11e7-810d-53ba20876a4a.png)
