### PR TITLE
minor font changes to uchiwa-default.css when displaying alerts

### DIFF
--- a/css/uchiwa-default/uchiwa-default.css
+++ b/css/uchiwa-default/uchiwa-default.css
@@ -1679,13 +1679,16 @@ li.timestamp .relative-timestamp {
   background-color: #FAFAFA; }
 
 .well-success {
-  border-left: 3px solid #43ac6a; }
+  border-left: 3px solid #43ac6a;
+  color: green; }
 
 .well-warning {
-  border-left: 3px solid #F9BA46; }
+  border-left: 3px solid #F9BA46;
+  color: orange; }
 
 .well-critical {
-  border-left: 3px solid #EA5443; }
+  border-left: 3px solid #EA5443;
+  color: red; }
 
 .well-unknown {
   border-left: 3px solid #9C9990; }


### PR DESCRIPTION
This rose as a requirement internally where we wanted to sort alerts based on their status to a specific colour code . Its an aesthetic change to make it easier to see the different levels of alerts on uchiwa. The current mapping is : 

critical   => red
warning => orange
success => green 