### PR TITLE
Replace 'never' expiration with 'on resolve' if applicable

### DIFF
--- a/partials/views/silenced.html
+++ b/partials/views/silenced.html
@@ -45,7 +45,6 @@
                 <th class="column-md" ng-click="predicate = 'dc'; reverse=!reverse"><i class="fa fa-cloud" tooltip-placement="top" tooltip-trigger uib-tooltip="Datacenter"></i> <i class="fa fa-sort"></i></th>
                 <th class="column-xxl" ng-click="predicate = 'reason'; reverse=!reverse"><i class="fa fa-commenting-o" tooltip-placement="top" tooltip-trigger uib-tooltip="Reason"></i> <i class="fa fa-sort"></i></th>
                 <th class="column-md" ng-click="predicate = 'creator'; reverse=!reverse"><i class="fa fa-user" tooltip-placement="top" tooltip-trigger uib-tooltip="Creator"></i> <i class="fa fa-sort"></i></th>
-                <th class="column-md trivial" ng-click="predicate = 'expire_on_resolve'; reverse=!reverse"><i class='fa fa-calendar-check-o' tooltip-placement="top" tooltip-trigger uib-tooltip="Expire on Resolve"></i> <i class="fa fa-sort"></i></th>
                 <th class="column-lg" ng-click="predicate = 'timestamp'; reverse=!reverse"><i class='fa fa-hourglass-start' tooltip-placement="top" tooltip-trigger uib-tooltip="Created"></i> <i class="fa fa-sort"></i></th>
                 <th class="column-lg" ng-click="predicate = 'expire'; reverse=!reverse"><i class='fa fa-hourglass-end' tooltip-placement="top" tooltip-trigger uib-tooltip="Expiration"></i> <i class="fa fa-sort"></i></th>
               </tr>
@@ -64,11 +63,17 @@
                   {{ entry.creator }}
                   <span ng-if="entry.creator === null">N/A</span>
                 </td>
-                <td class="normal trivial">{{ entry.expire_on_resolve }}</td>
                 <td data-title="Created" class="normal">
                   <relative-time timestamp="entry.timestamp"></relative-time>
                 </td>
-                <td data-title="Expire" class="normal">{{ entry.expire | getExpirationTimestamp }}</td>
+                <td data-title="Expire" class="normal">
+                  <span ng-if="!entry.expire_on_resolve">
+                    {{ entry.expire | getExpirationTimestamp }}
+                  </span>
+                  <span ng-if="entry.expire_on_resolve">
+                    On resolve
+                  </span>
+                </td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
Closes https://github.com/sensu/uchiwa/issues/764.

It replaces `Never` text on the _Expiration_ column if a silenced entry has `expire_on_resolve` set to `true` and removes the column for `expire_on_resolve`.