### PR TITLE
Add confirmation prompt when deleting silenced entry

### DIFF
--- a/test/karma/services-spec.js
+++ b/test/karma/services-spec.js
@@ -637,24 +637,24 @@ describe('services', function () {
         spyOn(Silenced, 'delete').and.callThrough();
 
         var entries = [
-          {_id: 'foo:bar', selected: true},
-          {_id: 'baz:qux', selected: true},
-          {_id: 'foo:baz', selected: false},
+          {_id: 'us-east-1:client:foo:bar', selected: true},
+          {_id: 'us-east-1:client:baz:qux', selected: true},
+          {_id: 'us-east-1:client:foo:baz', selected: false},
         ];
         Silenced.clearEntries(entries);
 
-        expect(Silenced.delete).toHaveBeenCalledWith('foo:bar');
-        expect(Silenced.delete).toHaveBeenCalledWith('baz:qux');
+        expect(Silenced.delete).toHaveBeenCalledWith('us-east-1:client:foo:bar');
+        expect(Silenced.delete).toHaveBeenCalledWith('us-east-1:client:baz:qux');
       }));
     });
 
     describe('delete', function() {
       it('sends a POST request to the silenced/clear endpoint', inject(function (Silenced) {
         $httpBackend.expectPOST('silenced/clear',
-        '{"dc":"foo","id":"bar"}')
+        '{"dc":"us-east-1","id":"client:foo:bar"}')
         .respond(200, '');
 
-        Silenced.delete('foo:bar');
+        Silenced.delete('us-east-1:client:foo:bar');
         $httpBackend.flush();
       }));
     });
@@ -712,19 +712,19 @@ describe('services', function () {
 
     describe('deleteSingle', function() {
       it('sends a POST request to the silenced/clear endpoint', inject(function (Silenced) {
-        $httpBackend.expectPOST('silenced/clear', '{"dc":"foo","id":"bar"}')
+        $httpBackend.expectPOST('silenced/clear', '{"dc":"us-east-1","id":"client:foo:bar"}')
         .respond(200, '');
 
-        Silenced.deleteSingle('foo:bar');
+        Silenced.deleteSingle('us-east-1:client:foo:bar');
         $httpBackend.flush();
         expect(mockNotification.success).toHaveBeenCalled();
       }));
 
       it('handles an error', inject(function (Silenced) {
-        $httpBackend.expectPOST('silenced/clear', '{"dc":"foo","id":"bar"}')
+        $httpBackend.expectPOST('silenced/clear', '{"dc":"us-east-1","id":"client:bar:*"}')
         .respond(500, '');
 
-        Silenced.deleteSingle('foo:bar');
+        Silenced.deleteSingle('us-east-1:client:bar:*');
         $httpBackend.flush();
         expect(mockNotification.error).toHaveBeenCalled();
       }));


### PR DESCRIPTION
It adds a confirmation prompt when deleting a silenced entry that could potentially affect more than a single client.

Closes https://github.com/sensu/uchiwa/issues/767.

![screen shot 2018-04-25 at 11 06 43 am](https://user-images.githubusercontent.com/4105580/39257144-cf60a0a6-487e-11e8-8c5a-7c76cf9990d1.png)