### PR TITLE
Fix aggregate's link in case of a boolean value

### DIFF
--- a/partials/views/client.html
+++ b/partials/views/client.html
@@ -109,7 +109,8 @@
                   <span class="key pull-right">{{key}}</span>
                 </div>
                 <div ng-if="key == 'aggregate'" class="col-xs-8">
-                  <a class="value" ng-href="#/aggregates/{{check.dc}}/{{value}}" ng-bind-html="value | highlight"></a>
+                  <a ng-if="value == 'true'" class="value" ng-href="#/aggregates/{{check.dc}}/{{check.check }}" ng-bind-html="check.check | highlight"></a>
+                  <a ng-if="value != 'true'" class="value" ng-href="#/aggregates/{{check.dc}}/{{value}}" ng-bind-html="value | highlight"></a>
                 </div>
                 <div ng-if="key == 'aggregates'" class="col-xs-8">
 		  <div ng-repeat="aggregate in value.split(', ')">


### PR DESCRIPTION
As per Sensu's documentation - https://docs.sensu.io/sensu-core/1.7/reference/checks/#check-attributes - named aggregates were only introduced in version 0.24.

> NOTE: named aggregates are new to Sensu version 0.24, now being defined with a String data type rather than a Boolean (i.e. true or false). Legacy check definitions with "aggregate": true attributes will default to using the check name as the aggregate name.

If the aggregation attribute is set to `true`, an aggregation is created using the check's name.

This PR fixes an issue in Uchiwa, where an incorrect link is created, pointing  to an (obviously un-existing) aggregation's page called `true`.

![sensu](https://user-images.githubusercontent.com/2865071/55673307-4fe51100-589e-11e9-85ee-f8e770de1006.png)

The fix is simply to point to the correct aggregation by using the check's name in the link if `true` is found.